### PR TITLE
Désactiver la création de salons privés non-chiffrés

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/CreateRoomDataStore.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/CreateRoomDataStore.kt
@@ -86,7 +86,8 @@ class CreateRoomDataStore @Inject constructor(
             config.copy(
                 roomVisibility = when (visibility) {
                     RoomVisibilityItem.Private -> RoomVisibilityState.Private
-                    RoomVisibilityItem.PrivateNotEncrypted -> RoomVisibilityState.PrivateNotEncrypted // TCHAP room type
+                    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
+//                    RoomVisibilityItem.PrivateNotEncrypted -> RoomVisibilityState.PrivateNotEncrypted // TCHAP room type
                     RoomVisibilityItem.Public -> {
                         val roomAliasName = roomAliasHelper.roomAliasNameFromRoomDisplayName(config.roomName.orEmpty())
                         RoomVisibilityState.Public(

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -196,19 +196,20 @@ class ConfigureRoomPresenter @Inject constructor(
                         avatar = avatarUrl,
                     )
                 }
-                is RoomVisibilityState.PrivateNotEncrypted -> { // TCHAP room type
-                    CreateRoomParameters(
-                        accessRules = accessRules,
-                        name = config.roomName,
-                        topic = config.topic,
-                        isEncrypted = false,
-                        isDirect = false,
-                        visibility = RoomVisibility.Private,
-                        preset = RoomPreset.PRIVATE_CHAT,
-                        invite = config.invites.map { it.userId },
-                        avatar = avatarUrl,
-                    )
-                }
+                // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
+//                is RoomVisibilityState.PrivateNotEncrypted -> { // TCHAP room type
+//                    CreateRoomParameters(
+//                        accessRules = accessRules,
+//                        name = config.roomName,
+//                        topic = config.topic,
+//                        isEncrypted = false,
+//                        isDirect = false,
+//                        visibility = RoomVisibility.Private,
+//                        preset = RoomPreset.PRIVATE_CHAT,
+//                        invite = config.invites.map { it.userId },
+//                        avatar = avatarUrl,
+//                    )
+//                }
             }
             matrixClient.createRoom(params)
                 .onFailure { failure ->

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
@@ -27,6 +27,7 @@ data class ConfigureRoomState(
 ) {
     val isValid: Boolean = config.roomName?.isNotEmpty() == true &&
         (config.roomVisibility is RoomVisibilityState.Private ||
-            config.roomVisibility is RoomVisibilityState.PrivateNotEncrypted || // TCHAP room type
+            // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
+//            config.roomVisibility is RoomVisibilityState.PrivateNotEncrypted || // TCHAP room type
             roomAddressValidity == RoomAddressValidity.Valid)
 }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
@@ -144,7 +144,8 @@ fun ConfigureRoomView(
             RoomVisibilityOptions(
                 selected = when (state.config.roomVisibility) {
                     is RoomVisibilityState.Private -> RoomVisibilityItem.Private
-                    is RoomVisibilityState.PrivateNotEncrypted -> RoomVisibilityItem.PrivateNotEncrypted // TCHAP room type
+                    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
+//                    is RoomVisibilityState.PrivateNotEncrypted -> RoomVisibilityItem.PrivateNotEncrypted // TCHAP room type
                     is RoomVisibilityState.Public -> RoomVisibilityItem.Public
                 },
                 onOptionClick = {

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityItem.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityItem.kt
@@ -23,11 +23,12 @@ enum class RoomVisibilityItem(
         title = R.string.tchap_screen_create_room_private_encrypted_option_title,
         description = R.string.tchap_screen_create_room_private_encrypted_option_description,
     ),
-    PrivateNotEncrypted(
-        icon = CompoundDrawables.ic_compound_lock_off,
-        title = R.string.screen_create_room_private_option_title,
-        description = R.string.tchap_screen_create_room_private_not_encrypted_option_description,
-    ),
+    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
+//    PrivateNotEncrypted(
+//        icon = CompoundDrawables.ic_compound_lock_off,
+//        title = R.string.screen_create_room_private_option_title,
+//        description = R.string.tchap_screen_create_room_private_not_encrypted_option_description,
+//    ),
     Public(
         icon = CompoundDrawables.ic_compound_public,
         title = R.string.screen_create_room_public_option_title,

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityState.kt
@@ -12,7 +12,8 @@ import java.util.Optional
 sealed interface RoomVisibilityState {
     data object Private : RoomVisibilityState
 
-    data object PrivateNotEncrypted : RoomVisibilityState // TCHAP room type
+    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
+//    data object PrivateNotEncrypted : RoomVisibilityState // TCHAP room type
 
     data class Public(
         val roomAddress: RoomAddress,
@@ -21,7 +22,8 @@ sealed interface RoomVisibilityState {
 
     fun roomAddress(): Optional<String> {
         return when (this) {
-            is PrivateNotEncrypted, // TCHAP room type
+            // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
+//            is PrivateNotEncrypted, // TCHAP room type
             is Private -> Optional.empty()
             is Public -> Optional.of(roomAddress.value)
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Close #73 - Désactiver la création de salons privés non-chiffrés

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
