### PR TITLE
Activation des rooms privées non-chiffrées

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -206,20 +206,22 @@ class ConfigureRoomPresenter(
                         isSpace = isSpace,
                     )
                 }
-                // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//                is RoomVisibilityState.PrivateNotEncrypted -> { // TCHAP room type
-//                    CreateRoomParameters(
-//                        accessRules = accessRules,
-//                        name = config.roomName,
-//                        topic = config.topic,
-//                        isEncrypted = false,
-//                        isDirect = false,
-//                        visibility = RoomVisibility.Private,
-//                        preset = RoomPreset.PRIVATE_CHAT,
-//                        invite = config.invites.map { it.userId },
-//                        avatar = avatarUrl,
-//                    )
-//                }
+                // TCHAP - Enable PrivateNotEncrypted room
+                is RoomVisibilityState.PrivateNotEncrypted -> { // TCHAP room type
+                    CreateRoomParameters(
+                        accessRules = accessRules,
+                        name = config.roomName,
+                        topic = config.topic,
+                        isEncrypted = false,
+                        isDirect = false,
+                        visibility = RoomVisibility.Private,
+                        historyVisibilityOverride = RoomHistoryVisibility.Invited,
+                        preset = RoomPreset.PRIVATE_CHAT,
+                        invite = config.invites.map { it.userId },
+                        avatar = avatarUrl,
+                        isSpace = isSpace,
+                    )
+                }
             }
             matrixClient.createRoom(params)
                 .onFailure { failure ->

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -106,6 +106,11 @@ class ConfigureRoomPresenter(
             }
         }
 
+        // TCHAP - PrivateNotEncrypted room feature flag
+        val isPrivateNotEncryptedRoomsActive by remember {
+            featureFlagService.isFeatureEnabledFlow(FeatureFlags.PrivateNotEncryptedRooms)
+        }.collectAsState(initial = false)
+
         LaunchedEffect(cameraPermissionState.permissionGranted) {
             if (cameraPermissionState.permissionGranted && pendingPermissionRequest) {
                 pendingPermissionRequest = false
@@ -164,6 +169,8 @@ class ConfigureRoomPresenter(
             homeserverName = homeserverName,
             roomAddressValidity = roomAddressValidity.value,
             eventSink = ::handleEvent,
+            // TCHAP - PrivateNotEncrypted room feature flag
+            isPrivateNotEncryptedRoomsActive = isPrivateNotEncryptedRoomsActive
         )
     }
 

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
@@ -23,7 +23,9 @@ data class ConfigureRoomState(
     val cameraPermissionState: PermissionsState,
     val roomAddressValidity: RoomAddressValidity,
     val homeserverName: String,
-    val eventSink: (ConfigureRoomEvents) -> Unit
+    val eventSink: (ConfigureRoomEvents) -> Unit,
+    // TCHAP - PrivateNotEncrypted room feature flag
+    val isPrivateNotEncryptedRoomsActive: Boolean,
 ) {
     val isValid: Boolean = config.roomName?.isNotEmpty() == true &&
         (config.roomVisibility is RoomVisibilityState.Private ||

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
@@ -27,7 +27,7 @@ data class ConfigureRoomState(
 ) {
     val isValid: Boolean = config.roomName?.isNotEmpty() == true &&
         (config.roomVisibility is RoomVisibilityState.Private ||
-            // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//            config.roomVisibility is RoomVisibilityState.PrivateNotEncrypted || // TCHAP room type
+            // TCHAP - Enable PrivateNotEncrypted room
+            config.roomVisibility is RoomVisibilityState.PrivateNotEncrypted || // TCHAP room type
             roomAddressValidity == RoomAddressValidity.Valid)
 }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomStateProvider.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomStateProvider.kt
@@ -111,4 +111,6 @@ fun aConfigureRoomState(
     homeserverName = homeserverName,
     roomAddressValidity = roomAddressValidity,
     eventSink = eventSink,
+    // TCHAP - PrivateNotEncrypted room feature flag
+    isPrivateNotEncryptedRoomsActive = true
 )

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
@@ -62,10 +62,8 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.ui.components.AvatarActionBottomSheet
 import io.element.android.libraries.matrix.ui.components.AvatarPickerState
 import io.element.android.libraries.matrix.ui.components.AvatarPickerView
-import io.element.android.libraries.matrix.ui.room.address.RoomAddressField
 import io.element.android.libraries.permissions.api.PermissionsView
 import io.element.android.libraries.ui.strings.CommonStrings
-import kotlin.jvm.optionals.getOrNull
 
 @Composable
 fun ConfigureRoomView(
@@ -122,8 +120,8 @@ fun ConfigureRoomView(
             RoomVisibilityAndAccessOptions(
                 selected = when (state.config.roomVisibility) {
                     is RoomVisibilityState.Private -> RoomVisibilityItem.Private
-                    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//                    is RoomVisibilityState.PrivateNotEncrypted -> RoomVisibilityItem.PrivateNotEncrypted // TCHAP room type
+                    // TCHAP - Enable PrivateNotEncrypted room
+                    is RoomVisibilityState.PrivateNotEncrypted -> RoomVisibilityItem.PrivateNotEncrypted // TCHAP room type
                     is RoomVisibilityState.Public -> when (state.config.roomVisibility.roomAccess) {
                         RoomAccess.Knocking -> RoomVisibilityItem.AskToJoin
                         RoomAccess.Anyone -> RoomVisibilityItem.Public
@@ -136,20 +134,21 @@ fun ConfigureRoomView(
                 },
             )
 
-            if (state.config.roomVisibility !is RoomVisibilityState.Private) {
-                Column {
-                    ListSectionHeader(title = stringResource(R.string.screen_create_room_room_address_section_title))
-                    RoomAddressField(
-                        modifier = Modifier.padding(horizontal = 16.dp),
-                        address = state.config.roomVisibility.roomAddress().getOrNull().orEmpty(),
-                        homeserverName = state.homeserverName,
-                        addressValidity = state.roomAddressValidity,
-                        onAddressChange = { state.eventSink(ConfigureRoomEvents.RoomAddressChanged(it)) },
-                        label = null,
-                        supportingText = stringResource(R.string.screen_create_room_room_address_section_footer),
-                    )
-                }
-            }
+            // TCHAP : Disable room address customization
+//            if (state.config.roomVisibility !is RoomVisibilityState.Private) {
+//                Column {
+//                    ListSectionHeader(title = stringResource(R.string.screen_create_room_room_address_section_title))
+//                    RoomAddressField(
+//                        modifier = Modifier.padding(horizontal = 16.dp),
+//                        address = state.config.roomVisibility.roomAddress().getOrNull().orEmpty(),
+//                        homeserverName = state.homeserverName,
+//                        addressValidity = state.roomAddressValidity,
+//                        onAddressChange = { state.eventSink(ConfigureRoomEvents.RoomAddressChanged(it)) },
+//                        label = null,
+//                        supportingText = stringResource(R.string.screen_create_room_room_address_section_footer),
+//                    )
+//                }
+//            }
         }
     }
 
@@ -306,8 +305,8 @@ private fun RoomVisibilityAndAccessOptions(
                             RoomVisibilityItem.Public -> CompoundDrawables.ic_compound_public
                             RoomVisibilityItem.AskToJoin -> CompoundDrawables.ic_compound_user_add
                             RoomVisibilityItem.Private -> CompoundDrawables.ic_compound_lock
-                            // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//                            RoomVisibilityItem.PrivateNotEncrypted -> CompoundDrawables.ic_compound_lock_off
+                            // TCHAP - Enable PrivateNotEncrypted room
+                            RoomVisibilityItem.PrivateNotEncrypted -> CompoundDrawables.ic_compound_lock_off
                         },
                         tint = if (isSelected) ElementTheme.colors.iconPrimary else ElementTheme.colors.iconSecondary,
                         backgroundTint = Color.Transparent,
@@ -317,20 +316,20 @@ private fun RoomVisibilityAndAccessOptions(
                     val title = when (item) {
                         RoomVisibilityItem.Public -> stringResource(R.string.screen_create_room_public_option_title)
                         RoomVisibilityItem.AskToJoin -> stringResource(R.string.screen_create_room_room_access_section_knocking_option_title)
-                        RoomVisibilityItem.Private -> stringResource(R.string.screen_create_room_private_option_title)
-                        // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//                        RoomVisibilityItem.PrivateNotEncrypted -> stringResource(R.string.screen_create_room_private_option_title)
+                        RoomVisibilityItem.Private -> stringResource(R.string.tchap_screen_create_room_private_encrypted_option_title)
+                        // TCHAP - Enable PrivateNotEncrypted room
+                        RoomVisibilityItem.PrivateNotEncrypted -> stringResource(R.string.tchap_screen_create_room_private_not_encrypted_option_title)
                     }
                     Text(text = title)
                 },
                 supportingContent = {
                     // TODO handle description of items in a certain space/org
                     val description = when (item) {
-                        RoomVisibilityItem.Public -> stringResource(R.string.screen_create_room_public_option_short_description)
+                        RoomVisibilityItem.Public -> stringResource(R.string.tchap_screen_create_room_public_option_description)
                         RoomVisibilityItem.AskToJoin -> stringResource(R.string.screen_create_room_room_access_section_knocking_option_description)
-                        RoomVisibilityItem.Private -> stringResource(R.string.screen_create_room_private_option_description)
-                        // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//                        RoomVisibilityItem.PrivateNotEncrypted -> stringResource(R.string.tchap_screen_create_room_private_not_encrypted_option_description)
+                        RoomVisibilityItem.Private -> stringResource(R.string.tchap_screen_create_room_private_encrypted_option_description)
+                        // TCHAP - Enable PrivateNotEncrypted room
+                        RoomVisibilityItem.PrivateNotEncrypted -> stringResource(R.string.tchap_screen_create_room_private_not_encrypted_option_description)
                     }
                     Text(text = description)
                 },

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomView.kt
@@ -132,6 +132,8 @@ fun ConfigureRoomView(
                     focusManager.clearFocus()
                     state.eventSink(ConfigureRoomEvents.RoomVisibilityChanged(it))
                 },
+                // TCHAP - PrivateNotEncrypted room feature flag
+                isPrivateNotEncryptedRoomsActive = state.isPrivateNotEncryptedRoomsActive
             )
 
             // TCHAP : Disable room address customization
@@ -283,6 +285,8 @@ private fun RoomVisibilityAndAccessOptions(
     selected: RoomVisibilityItem,
     isKnockingEnabled: Boolean,
     onOptionClick: (RoomVisibilityItem) -> Unit,
+    // TCHAP - PrivateNotEncrypted room feature flag
+    isPrivateNotEncryptedRoomsActive: Boolean,
     modifier: Modifier = Modifier,
 ) {
     ConfigureRoomOptions(
@@ -293,6 +297,11 @@ private fun RoomVisibilityAndAccessOptions(
     ) {
         RoomVisibilityItem.entries.forEach { item ->
             if (item == RoomVisibilityItem.AskToJoin && !isKnockingEnabled) {
+                return@forEach
+            }
+
+            // TCHAP - PrivateNotEncrypted room feature flag
+            if (item == RoomVisibilityItem.PrivateNotEncrypted && !isPrivateNotEncryptedRoomsActive) {
                 return@forEach
             }
 

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/CreateRoomConfigStore.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/CreateRoomConfigStore.kt
@@ -72,8 +72,8 @@ class CreateRoomConfigStore(
             config.copy(
                 roomVisibility = when (visibility) {
                     RoomVisibilityItem.Private -> RoomVisibilityState.Private
-                    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//                    RoomVisibilityItem.PrivateNotEncrypted -> RoomVisibilityState.PrivateNotEncrypted // TCHAP room type
+                    // TCHAP - Enable PrivateNotEncrypted room
+                    RoomVisibilityItem.PrivateNotEncrypted -> RoomVisibilityState.PrivateNotEncrypted // TCHAP room type
                     RoomVisibilityItem.Public, RoomVisibilityItem.AskToJoin -> {
                         val roomAliasName = roomAliasHelper.roomAliasNameFromRoomDisplayName(config.roomName.orEmpty())
                         RoomVisibilityState.Public(

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityItem.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityItem.kt
@@ -9,9 +9,11 @@
 package io.element.android.features.createroom.impl.configureroom
 
 enum class RoomVisibilityItem {
+    Private,
+
+    // TCHAP - Enable PrivateNotEncrypted room
+    PrivateNotEncrypted,
+
     Public,
     AskToJoin,
-    Private,
-    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//    PrivateNotEncrypted
 }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityState.kt
@@ -13,8 +13,8 @@ import java.util.Optional
 sealed interface RoomVisibilityState {
     data object Private : RoomVisibilityState
 
-    // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//    data object PrivateNotEncrypted : RoomVisibilityState // TCHAP room type
+    // TCHAP - Enable PrivateNotEncrypted room
+    data object PrivateNotEncrypted : RoomVisibilityState // TCHAP room type
 
     data class Public(
         val roomAddress: RoomAddress,
@@ -23,8 +23,8 @@ sealed interface RoomVisibilityState {
 
     fun roomAddress(): Optional<String> {
         return when (this) {
-            // TCHAP - Disable PrivateNotEncrypted room, waiting for back implementation
-//            is PrivateNotEncrypted, // TCHAP room type
+            // TCHAP - Enable PrivateNotEncrypted room
+            is PrivateNotEncrypted, // TCHAP room type
             is Private -> Optional.empty()
             is Public -> Optional.of(roomAddress.value)
         }

--- a/features/createroom/impl/src/main/res/values-fr/strings_tchap.xml
+++ b/features/createroom/impl/src/main/res/values-fr/strings_tchap.xml
@@ -24,15 +24,14 @@
 
 <resources>
     <string name="tchap_screen_create_room_room_access_encryption_section_title">"Sécurité et accès du salon"</string>
+    <string name="tchap_screen_create_room_private_encrypted_option_title">"Salon privé sécurisé"</string>
     <string name="tchap_screen_create_room_private_encrypted_option_description">"• Chiffré de bout en bout
 • Accessible uniquement sur invitation
 • Conseillé jusqu’à 500 membres"</string>
-    <string name="tchap_screen_create_room_private_encrypted_option_title">"Salon privé sécurisé"</string>
+    <string name="tchap_screen_create_room_private_not_encrypted_option_title">"Salon privé"</string>
     <string name="tchap_screen_create_room_private_not_encrypted_option_description">"• Non‑chiffré
 • Accessible uniquement sur invitation"</string>
     <string name="tchap_screen_create_room_public_option_description">"• Non‑chiffré
 • Accessible depuis la liste des salons
 • Non accessible aux invités externes"</string>
-    <string name="tchap_screen_create_room_external_guests_warning_title">"Ce salon compte des %1$s. %2$s."</string>
-    <string name="tchap_screen_create_room_external_guests_content">"invités externes"</string>
 </resources>

--- a/features/createroom/impl/src/main/res/values/strings_tchap.xml
+++ b/features/createroom/impl/src/main/res/values/strings_tchap.xml
@@ -24,15 +24,14 @@
 
 <resources>
     <string name="tchap_screen_create_room_room_access_encryption_section_title">"Room Access and Security"</string>
+    <string name="tchap_screen_create_room_private_encrypted_option_title">"Secure private room"</string>
     <string name="tchap_screen_create_room_private_encrypted_option_description">"• End to end Encrypted
 • Access by invite only
 • Recommended for up to 500 members"</string>
-    <string name="tchap_screen_create_room_private_encrypted_option_title">"Secure private room"</string>
+    <string name="tchap_screen_create_room_private_not_encrypted_option_title">"Private room"</string>
     <string name="tchap_screen_create_room_private_not_encrypted_option_description">"• Not encrypted
 • Access by invite only</string>
     <string name="tchap_screen_create_room_public_option_description">"• Not encrypted messages
 • Accessible from rooms directory
 • Not accessible to external guests"</string>
-    <string name="tchap_screen_create_room_external_guests_warning_title">"This room contains some %1$s. %2$s."</string>
-    <string name="tchap_screen_create_room_external_guests_content">"external guests"</string>
 </resources>

--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -150,4 +150,12 @@ enum class FeatureFlags(
         defaultValue = { false },
         isFinished = false,
     ),
+
+    // TCHAP - PrivateNotEncrypted room feature flag
+    PrivateNotEncryptedRooms(
+        key = "feature.private_not_encrypted_rooms",
+        title = "Active Private Not Encrypted rooms",
+        defaultValue = { false },
+        isFinished = false,
+    ),
 }

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c3044cd0997d75829a7b5051c31cb6fcf06e4df8a569a7f38b0ed11431b42b7c
-size 32433
+oid sha256:c30be885fa08ea9a1b66f57fcee2fda31aee41194127546f0eb86e6fb85e884a
+size 48977

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:bfac981a9f79c46f84c1b1f599f994f99bee6ddcdd51c2cba4ab1ea9a3621424
-size 37344
+oid sha256:86a00f31a35d5904ad98085ade980ffecb1beda6427125fd077c48c132dda471
+size 45964

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b538ade1495535f4e37f9fcd3f51e31fb4f49e30614b793de1725de6fdc12825
-size 45572
+oid sha256:3d43df14a5c2dd194e24a872328098863affd757880056d4215de22030c4a33e
+size 53924

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_3_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:01d495be83f9bcc3dbb80717e7a47c2b0f9d066c8db96210f9d617b6f12e6fab
-size 46331
+oid sha256:08e8930aa33263e3b084fbfbb19e7d65aed1c64316b787f7c13315518e0e254b
+size 54026

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7cd647b923966ea892e565c1b6a91f2ec611da7ee62ca07fd3f214099f52c6bf
-size 48128
+oid sha256:08e8930aa33263e3b084fbfbb19e7d65aed1c64316b787f7c13315518e0e254b
+size 54026

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_5_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b538ade1495535f4e37f9fcd3f51e31fb4f49e30614b793de1725de6fdc12825
-size 45572
+oid sha256:3d43df14a5c2dd194e24a872328098863affd757880056d4215de22030c4a33e
+size 53924

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_6_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewDark_6_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:2bac8f867e6053e860466aaa5236b0aa3b8b43f0b3df06aac7f42b5e1af24888
-size 46571
+oid sha256:2e223b6c8ba6ed81da0209a4d17684d94946ac9d9fb85c7d061410d20d267519
+size 54817

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_0_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_0_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f21cf0a01f33f1e3fd1f1bb13f3080dad86b69101706670731ff1a559b594b4d
-size 31442
+oid sha256:d77b01e95fcb5de5482c5d9de1bb9deff42e5f52bf8b890c73fd5c3db2f63861
+size 47142

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_1_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_1_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4ab262d032235b8caee905ad6c84a66ab4fd1ed9ccb099aad1a4cb94ac9584b0
-size 36434
+oid sha256:81b3f0c932a0f1cd37b40cd07e2922798fdd5376811cd84d67c5fe3632ffcbd7
+size 44393

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_2_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_2_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd3415670d2b59bcdf74f99db9a8d05bd38fb9b2d093e04ddc2a2263b1a6124c
-size 44413
+oid sha256:0eaa4eeb1d1800d077ba4faf54fe2019eb39b0859c1b00c14a8b78dc434edcf9
+size 51978

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_3_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_3_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:14d15f8af95f62bd01242b3f61368c95e3e1a4bd515d4901458de6de39a6f571
-size 45327
+oid sha256:34c8a67b556cb572364c6c0b3f7b5f7490563b6e6062510e967e73acb765e2ac
+size 52034

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_4_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_4_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:98df101d70bf303746294d467b4bdca1dc841e5e5e7ff6eb43a2a325475a443d
-size 47118
+oid sha256:34c8a67b556cb572364c6c0b3f7b5f7490563b6e6062510e967e73acb765e2ac
+size 52034

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_5_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_5_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:fd3415670d2b59bcdf74f99db9a8d05bd38fb9b2d093e04ddc2a2263b1a6124c
-size 44413
+oid sha256:0eaa4eeb1d1800d077ba4faf54fe2019eb39b0859c1b00c14a8b78dc434edcf9
+size 51978

--- a/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_6_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.createroom.impl.configureroom_ConfigureRoomViewLight_6_en.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:91b2e94a111f2e7ece1f82850ebb0fd60c244aadfb7dd6563738eeb722e5dddd
-size 45376
+oid sha256:4775bf55ae0172f5988338ad9e880e648548d506645768213626d2285f010908
+size 52779


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Activer les salons privés non chiffrés #90 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
