### PR TITLE
Correction des délais inutiles lors de la récupération de access_rules.visibility via une requête

### DIFF
--- a/libraries/rustsdk/matrix-rust-sdk.aar
+++ b/libraries/rustsdk/matrix-rust-sdk.aar
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f79be4496ff47f58a5ded9e2fbe5a0e6ff2ae0608db53917b88af5f04fd64a44
-size 121358073
+oid sha256:cfec8ade549cd4be1829eec6da403e5541684a39a2dfe95f5fab56e9fb437a2e
+size 121338446


### PR DESCRIPTION
…s.visibility via une requête

<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Correction des délais inutiles lors de la récupération de access_rules.visibility via une requête.

Un fix temporaire côté Rust SDK a été réalisé : 
- En fallback, on ne récupère plus la valeur via une requête API
- On vérifie si la room est chiffrée ou non : 
  - `Visibility::Public` -> `room.encrypted === false`
  - `Visibility::Private` -> `room.encrypted === true`

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
