### PR TITLE
Correction de la création des salons privés non chiffrés

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -277,26 +277,9 @@ class ConfigureRoomPresenter(
                         accessRules = accessRules,
                         name = config.roomName,
                         topic = config.topic,
-                        isEncrypted = true,
-                        isDirect = false,
-                        visibility = RoomVisibility.Private,
-                        historyVisibilityOverride = RoomHistoryVisibility.Invited,
-                        joinRuleOverride = config.visibilityState.joinRuleItem.toJoinRule()
-                            // No need to specify the Invite join rule override, since the preset is already PRIVATE_CHAT
-                            .takeIf { it != JoinRule.Invite },
-                        preset = RoomPreset.PRIVATE_CHAT,
-                        invite = config.invites.map { it.userId },
-                        avatar = avatarUrl,
-                        isSpace = isSpace,
-                    )
-                }
-                // TCHAP - Enable PrivateNotEncrypted room
-                is RoomVisibilityState.PrivateNotEncrypted -> { // TCHAP room type
-                    CreateRoomParameters(
-                        accessRules = accessRules,
-                        name = config.roomName,
-                        topic = config.topic,
-                        isEncrypted = false,
+                        // TCHAP - Enable PrivateNotEncrypted room
+//                        isEncrypted = true,
+                        isEncrypted = config.visibilityState.joinRuleItem != JoinRuleItem.PrivateVisibility.PrivateNotEncrypted,
                         isDirect = false,
                         visibility = RoomVisibility.Private,
                         historyVisibilityOverride = RoomHistoryVisibility.Invited,

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomState.kt
@@ -30,8 +30,6 @@ data class ConfigureRoomState(
 ) {
     val isValid: Boolean = config.roomName?.isNotEmpty() == true &&
         (config.visibilityState is RoomVisibilityState.Private ||
-            // TCHAP - Enable PrivateNotEncrypted room
-            config.visibilityState is RoomVisibilityState.PrivateNotEncrypted || // TCHAP room type
             roomAddressValidity == RoomAddressValidity.Valid) &&
         config.visibilityState.joinRuleItem in availableJoinRules
 }

--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityState.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/RoomVisibilityState.kt
@@ -14,9 +14,6 @@ sealed interface RoomVisibilityState {
     val joinRuleItem: JoinRuleItem
     data class Private(override val joinRuleItem: JoinRuleItem.PrivateVisibility) : RoomVisibilityState
 
-    // TCHAP - Enable PrivateNotEncrypted room
-    data class PrivateNotEncrypted(override val joinRuleItem: JoinRuleItem.PrivateVisibility) : RoomVisibilityState
-
     data class Public(
         val roomAddress: RoomAddress,
         override val joinRuleItem: JoinRuleItem.PublicVisibility,
@@ -24,8 +21,6 @@ sealed interface RoomVisibilityState {
 
     fun roomAddress(): Optional<String> {
         return when (this) {
-            // TCHAP - Enable PrivateNotEncrypted room
-            is PrivateNotEncrypted, // TCHAP room type
             is Private -> Optional.empty()
             is Public -> Optional.of(roomAddress.value)
         }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Correction de la création des salons privés non chiffrés

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [ ] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
