### PR TITLE
Désactiver les screenshots sur l'application

### DIFF
--- a/features/lockscreen/api/src/main/kotlin/io/element/android/features/lockscreen/api/LockScreenService.kt
+++ b/features/lockscreen/api/src/main/kotlin/io/element/android/features/lockscreen/api/LockScreenService.kt
@@ -34,6 +34,12 @@ interface LockScreenService {
      * @return true if the pin is setup, false otherwise.
      */
     fun isPinSetup(): Flow<Boolean>
+
+    /**
+     * TCHAP : disable-screenshots
+     * Check isDebug to allow screenshots.
+     */
+    val isDebug: Boolean
 }
 
 /**
@@ -43,10 +49,15 @@ interface LockScreenService {
 fun LockScreenService.handleSecureFlag(activity: ComponentActivity) {
     isPinSetup()
         .onEach { isPinSetup ->
+            // TCHAP : disable-screenshots
+            // Enable screenshots only in debug and when the Pin is not Setup
+            val enableScreenshots = isDebug && !isPinSetup
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                activity.setRecentsScreenshotEnabled(!isPinSetup)
+//                activity.setRecentsScreenshotEnabled(!isPinSetup)
+                activity.setRecentsScreenshotEnabled(enableScreenshots)
             } else {
-                if (isPinSetup) {
+//                if (isPinSetup) {
+                if (!enableScreenshots) {
                     activity.window.setFlags(
                         WindowManager.LayoutParams.FLAG_SECURE,
                         WindowManager.LayoutParams.FLAG_SECURE

--- a/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
+++ b/features/lockscreen/impl/src/main/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenService.kt
@@ -18,6 +18,8 @@ import io.element.android.features.lockscreen.impl.biometric.DefaultBiometricUnl
 import io.element.android.features.lockscreen.impl.pin.DefaultPinCodeManagerCallback
 import io.element.android.features.lockscreen.impl.pin.PinCodeManager
 import io.element.android.features.lockscreen.impl.storage.LockScreenStore
+import io.element.android.libraries.core.meta.BuildMeta
+import io.element.android.libraries.core.meta.BuildType
 import io.element.android.libraries.di.annotations.AppCoroutineScope
 import io.element.android.libraries.sessionstorage.api.observer.SessionListener
 import io.element.android.libraries.sessionstorage.api.observer.SessionObserver
@@ -43,10 +45,14 @@ class DefaultLockScreenService(
     private val coroutineScope: CoroutineScope,
     private val sessionObserver: SessionObserver,
     private val appForegroundStateService: AppForegroundStateService,
+    buildMeta: BuildMeta,
     biometricAuthenticatorManager: BiometricAuthenticatorManager,
 ) : LockScreenService {
     private val _lockState = MutableStateFlow<LockScreenLockState>(LockScreenLockState.Unlocked)
     override val lockState: StateFlow<LockScreenLockState> = _lockState
+
+    // TCHAP : disable-screenshots (isDebug allow screenshots)
+    override val isDebug: Boolean = buildMeta.buildType == BuildType.DEBUG
 
     private var lockJob: Job? = null
 

--- a/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenServiceTest.kt
+++ b/features/lockscreen/impl/src/test/kotlin/io/element/android/features/lockscreen/impl/DefaultLockScreenServiceTest.kt
@@ -17,6 +17,8 @@ import io.element.android.features.lockscreen.impl.pin.PinCodeManager
 import io.element.android.features.lockscreen.impl.pin.createDefaultPinCodeManager
 import io.element.android.features.lockscreen.impl.pin.storage.InMemoryLockScreenStore
 import io.element.android.features.lockscreen.impl.storage.LockScreenStore
+import io.element.android.libraries.core.meta.BuildMeta
+import io.element.android.libraries.matrix.test.core.aBuildMeta
 import io.element.android.libraries.sessionstorage.api.observer.SessionObserver
 import io.element.android.libraries.sessionstorage.test.observer.FakeSessionObserver
 import io.element.android.services.appnavstate.api.AppForegroundStateService
@@ -85,6 +87,7 @@ private fun TestScope.createDefaultLockScreenService(
     sessionObserver: SessionObserver = FakeSessionObserver(),
     appForegroundStateService: AppForegroundStateService = FakeAppForegroundStateService(),
     biometricAuthenticatorManager: BiometricAuthenticatorManager = FakeBiometricAuthenticatorManager(),
+    buildMeta: BuildMeta = aBuildMeta(),
 ) = DefaultLockScreenService(
     lockScreenConfig = lockScreenConfig,
     lockScreenStore = lockScreenStore,
@@ -93,4 +96,5 @@ private fun TestScope.createDefaultLockScreenService(
     sessionObserver = sessionObserver,
     appForegroundStateService = appForegroundStateService,
     biometricAuthenticatorManager = biometricAuthenticatorManager,
+    buildMeta = buildMeta,
 )

--- a/features/lockscreen/test/src/main/kotlin/io/element/android/features/lockscreen/test/FakeLockScreenService.kt
+++ b/features/lockscreen/test/src/main/kotlin/io/element/android/features/lockscreen/test/FakeLockScreenService.kt
@@ -20,6 +20,8 @@ class FakeLockScreenService : LockScreenService {
     private val _lockState: MutableStateFlow<LockScreenLockState> = MutableStateFlow(LockScreenLockState.Locked)
     override val lockState: StateFlow<LockScreenLockState> = _lockState
 
+    override var isDebug: Boolean = true
+
     override fun isSetupRequired(): Flow<Boolean> {
         return isPinSetup.map { !it }
     }

--- a/features/rageshake/api/src/main/kotlin/io/element/android/features/rageshake/api/detection/RageshakeDetectionView.kt
+++ b/features/rageshake/api/src/main/kotlin/io/element/android/features/rageshake/api/detection/RageshakeDetectionView.kt
@@ -8,7 +8,11 @@
 
 package io.element.android.features.rageshake.api.detection
 
+import android.os.Build
+import android.view.WindowManager
+import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberUpdatedState
@@ -33,6 +37,10 @@ fun RageshakeDetectionView(
 ) {
     val eventSink = state.eventSink
     val context = LocalContext.current
+
+    // TCHAP : disable-screenshots
+    AllowScreenshotEffect(state.takeScreenshot || state.showDialog)
+
     OnLifecycleEvent { _, event ->
         when (event) {
             Lifecycle.Event.ON_RESUME -> eventSink(RageshakeDetectionEvent.StartDetection)
@@ -53,6 +61,32 @@ fun RageshakeDetectionView(
                 onDisableClick = { eventSink(RageshakeDetectionEvent.Disable) },
                 onYesClick = onOpenBugReport
             )
+        }
+    }
+}
+
+// TCHAP : disable-screenshots
+@Composable
+private fun AllowScreenshotEffect(enabled: Boolean) {
+    val activity = LocalActivity.current ?: return
+    DisposableEffect(enabled) {
+        if (enabled) {
+            val window = activity.window
+            val wasSecure = window.attributes.flags and WindowManager.LayoutParams.FLAG_SECURE != 0
+            window.clearFlags(WindowManager.LayoutParams.FLAG_SECURE)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                activity.setRecentsScreenshotEnabled(true)
+            }
+            onDispose {
+                if (wasSecure) {
+                    window.addFlags(WindowManager.LayoutParams.FLAG_SECURE)
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                        activity.setRecentsScreenshotEnabled(false)
+                    }
+                }
+            }
+        } else {
+            onDispose {}
         }
     }
 }


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Désactiver les screenshots sur l'application

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [x] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
