### PR TITLE
Nettoyage des access_rules à la création de salons

### DIFF
--- a/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
+++ b/features/createroom/impl/src/main/kotlin/io/element/android/features/createroom/impl/configureroom/ConfigureRoomPresenter.kt
@@ -33,7 +33,6 @@ import io.element.android.libraries.featureflag.api.FeatureFlags
 import io.element.android.libraries.matrix.api.MatrixClient
 import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.createroom.CreateRoomParameters
-import io.element.android.libraries.matrix.api.createroom.RoomAccessRules
 import io.element.android.libraries.matrix.api.createroom.RoomPreset
 import io.element.android.libraries.matrix.api.room.alias.RoomAliasHelper
 import io.element.android.libraries.matrix.api.room.history.RoomHistoryVisibility
@@ -250,12 +249,10 @@ class ConfigureRoomPresenter(
         createRoomAction: MutableState<AsyncAction<RoomId>>
     ) = launch {
         suspend {
-            val accessRules = RoomAccessRules.RESTRICTED
             val avatarUrl = config.avatarUri?.let { uploadAvatar(it.toUri()) }
             val params = when (config.visibilityState) {
                 is RoomVisibilityState.Public -> {
                     CreateRoomParameters(
-                        accessRules = accessRules,
                         name = config.roomName,
                         topic = config.topic,
                         isEncrypted = false,
@@ -274,7 +271,6 @@ class ConfigureRoomPresenter(
                 }
                 is RoomVisibilityState.Private -> {
                     CreateRoomParameters(
-                        accessRules = accessRules,
                         name = config.roomName,
                         topic = config.topic,
                         // TCHAP - Enable PrivateNotEncrypted room

--- a/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/createroom/CreateRoomParameters.kt
+++ b/libraries/matrix/api/src/main/kotlin/io/element/android/libraries/matrix/api/createroom/CreateRoomParameters.kt
@@ -15,7 +15,6 @@ import io.element.android.libraries.matrix.api.roomdirectory.RoomVisibility
 import java.util.Optional
 
 data class CreateRoomParameters(
-    val accessRules: RoomAccessRules? = null,
     val name: String?,
     val topic: String? = null,
     val isEncrypted: Boolean,

--- a/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
+++ b/libraries/matrix/impl/src/main/kotlin/io/element/android/libraries/matrix/impl/RustMatrixClient.kt
@@ -28,7 +28,6 @@ import io.element.android.libraries.matrix.api.core.RoomId
 import io.element.android.libraries.matrix.api.core.RoomIdOrAlias
 import io.element.android.libraries.matrix.api.core.UserId
 import io.element.android.libraries.matrix.api.createroom.CreateRoomParameters
-import io.element.android.libraries.matrix.api.createroom.RoomAccessRules
 import io.element.android.libraries.matrix.api.createroom.RoomPreset
 import io.element.android.libraries.matrix.api.linknewdevice.LinkDesktopHandler
 import io.element.android.libraries.matrix.api.linknewdevice.LinkMobileHandler
@@ -126,7 +125,6 @@ import org.matrix.rustcomponents.sdk.SendQueueRoomErrorListener
 import org.matrix.rustcomponents.sdk.TaskHandle
 import org.matrix.rustcomponents.sdk.use
 import timber.log.Timber
-import uniffi.matrix_sdk.AccessRule
 import java.io.File
 import java.util.Optional
 import kotlin.jvm.optionals.getOrNull
@@ -377,7 +375,7 @@ class RustMatrixClient(
             // TCHAP invite-by-email
             var isTchapInvite = false
             var isTchapInviteExternal = false
-            if (createRoomParams.accessRules === RoomAccessRules.DIRECT &&
+            if (createRoomParams.isDirect &&
                 createRoomParams.invite?.get(0)?.value?.contains(TchapPatterns.inviteByEmailSuffixMarker()) == true) {
                 // isTchapInvite = true when room is DM & first invite userId contains inviteByEmailSuffixMarker
                 isTchapInvite = true
@@ -388,16 +386,10 @@ class RustMatrixClient(
             val powerLevels = defaultRoomCreationPowerLevels(isSpace = createRoomParams.isSpace, isPublic = hasPublicAccess)
 
             val rustParams = RustCreateRoomParameters(
-                accessRuleOverride = when (createRoomParams.accessRules) {
-                    RoomAccessRules.DIRECT -> AccessRule.DIRECT
-                    RoomAccessRules.UNRESTRICTED -> AccessRule.UNRESTRICTED
-                    RoomAccessRules.RESTRICTED -> AccessRule.RESTRICTED
-                    // TCHAP access rule - Default room is UNRESTRICTED
-                    else -> AccessRule.UNRESTRICTED
-                },
                 name = createRoomParams.name,
                 topic = createRoomParams.topic,
                 isEncrypted = createRoomParams.isEncrypted,
+                // Tchap-specific : access_rules (federate param on creation_content)
                 isRoomFederated = createRoomParams.isRoomFederated,
                 isDirect = createRoomParams.isDirect,
                 visibility = createRoomParams.visibility.map(),
@@ -434,7 +426,6 @@ class RustMatrixClient(
 
     override suspend fun createDM(userId: UserId): Result<RoomId> {
         val createRoomParams = CreateRoomParameters(
-            accessRules = RoomAccessRules.DIRECT, // Tchap: make accessRules `direct` for Direct room.
             name = null,
             isEncrypted = true,
             isDirect = true,


### PR DESCRIPTION
<!-- Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request -->
 
## Content

Nettoyage des access_rules à la création de salons

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly define what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
