### PR TITLE
Texte d'alerte lors du partage d'un fichier dans un salon non chiffré

### DIFF
--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewPresenter.kt
@@ -11,6 +11,7 @@ package io.element.android.features.messages.impl.attachments.preview
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,6 +40,8 @@ import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeVideo
 import io.element.android.libraries.di.annotations.SessionCoroutineScope
 import io.element.android.libraries.matrix.api.core.EventId
 import io.element.android.libraries.matrix.api.permalink.PermalinkBuilder
+import io.element.android.libraries.matrix.api.room.JoinedRoom
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.timeline.Timeline
 import io.element.android.libraries.mediaupload.api.MediaOptimizationConfig
 import io.element.android.libraries.mediaupload.api.MediaOptimizationConfigProvider
@@ -63,6 +66,9 @@ class AttachmentsPreviewPresenter(
     @Assisted private val onDoneListener: OnDoneListener,
     @Assisted private val timelineMode: Timeline.Mode,
     @Assisted private val inReplyToEventId: EventId?,
+    // :tchap: Warning on file upload when room is not encrypted
+    private val room: JoinedRoom,
+    // :tchap: end
     mediaSenderFactory: MediaSenderFactory,
     private val permalinkBuilder: PermalinkBuilder,
     private val temporaryUriDeleter: TemporaryUriDeleter,
@@ -102,9 +108,18 @@ class AttachmentsPreviewPresenter(
         var editedTempFile by remember { mutableStateOf<File?>(null) }
 
         val markdownTextEditorState = rememberMarkdownTextEditorState(initialText = null, initialFocus = false)
+
+        // :tchap: Warning on file upload when room is not encrypted
+        val roomInfo by room.roomInfoFlow.collectAsState()
         val textEditorState by rememberUpdatedState(
-            TextEditorState.Markdown(markdownTextEditorState, isRoomEncrypted = null)
+//            TextEditorState.Markdown(markdownTextEditorState, isRoomEncrypted = null)
+            TextEditorState.Markdown(
+                markdownTextEditorState,
+                isRoomEncrypted = roomInfo.isEncrypted == true,
+                isRoomJoinRulePublic = roomInfo.joinRule == JoinRule.Public
+            )
         )
+        // :tchap: end
 
         val ongoingSendAttachmentJob = remember { mutableStateOf<Job?>(null) }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewStateProvider.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewStateProvider.kt
@@ -62,6 +62,11 @@ open class AttachmentsPreviewStateProvider : PreviewParameterProvider<Attachment
                     displayVideoPresetSelectorDialog = true,
                 )
             ),
+            // :tchap: Warning on file upload when room is not encrypted
+            anAttachmentsPreviewState(
+                textEditorState = aTextEditorStateMarkdown(isRoomEncrypted = false)
+            ),
+            // :tchap: end
         )
 }
 

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/attachments/preview/AttachmentsPreviewView.kt
@@ -11,6 +11,7 @@ package io.element.android.features.messages.impl.attachments.preview
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
@@ -21,6 +22,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -29,6 +32,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.heading
@@ -37,6 +41,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.unit.dp
 import io.element.android.compound.theme.ElementTheme
+import io.element.android.compound.tokens.generated.CompoundIcons
 import io.element.android.features.messages.impl.R
 import io.element.android.features.messages.impl.attachments.Attachment
 import io.element.android.features.messages.impl.attachments.preview.error.sendAttachmentError
@@ -45,6 +50,7 @@ import io.element.android.features.messages.impl.attachments.video.MediaOptimiza
 import io.element.android.features.messages.impl.attachments.video.MediaOptimizationSelectorState
 import io.element.android.features.messages.impl.attachments.video.VideoUploadEstimation
 import io.element.android.libraries.core.bool.orFalse
+import io.element.android.libraries.core.bool.orTrue
 import io.element.android.libraries.core.mimetype.MimeTypes.isMimeTypeVideo
 import io.element.android.libraries.designsystem.components.ProgressDialog
 import io.element.android.libraries.designsystem.components.ProgressDialogType
@@ -57,8 +63,10 @@ import io.element.android.libraries.designsystem.modifiers.niceClickable
 import io.element.android.libraries.designsystem.preview.ElementPreview
 import io.element.android.libraries.designsystem.preview.ElementPreviewDark
 import io.element.android.libraries.designsystem.preview.PreviewsDayNight
+import io.element.android.libraries.designsystem.theme.components.Icon
 import io.element.android.libraries.designsystem.theme.components.ListItem
 import io.element.android.libraries.designsystem.theme.components.Scaffold
+import io.element.android.libraries.designsystem.theme.components.Surface
 import io.element.android.libraries.designsystem.theme.components.Switch
 import io.element.android.libraries.designsystem.theme.components.Text
 import io.element.android.libraries.designsystem.theme.components.TextButton
@@ -269,6 +277,53 @@ private fun AttachmentPreviewContent(
                 }
             }
         }
+
+        // :tchap: Warning on file upload when room is not encrypted
+        if (state.textEditorState.isRoomEncrypted?.orFalse() == false) {
+            Surface(
+                modifier = Modifier.padding(
+                    start = 16.dp,
+                    top = 16.dp,
+                    end = 16.dp,
+                    bottom = 0.dp,
+                ),
+//                color = ElementTheme.colors.bgBadgeExternal,
+                // TODO Tchap : Use compound value above
+                color = Color(0xff570000),
+                shape = RoundedCornerShape(10.dp)
+            ) {
+                Row(
+                    modifier = Modifier.padding(
+                        horizontal = 15.dp,
+                        vertical = 13.dp,
+                    ),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(14.dp),
+                ) {
+                    Icon(
+                        modifier = Modifier.size(20.dp),
+//                        tint = ElementTheme.colors.iconBadgeExternal,
+                        // TODO Tchap : Use compound value above
+                        tint = Color(0xfff59629),
+                        imageVector = CompoundIcons.Warning(),
+                        contentDescription = null,
+                    )
+                    Text(
+                        text = if (state.textEditorState.isRoomJoinRulePublic?.orTrue() == true) {
+                            stringResource(R.string.tchap_screen_media_upload_unencrypted_public_warning)
+                        } else {
+                            stringResource(R.string.tchap_screen_media_upload_unencrypted_warning)
+                        },
+                        // TODO Tchap : Use compound value above
+//                        color = ElementTheme.colors.textBadgeExternal,
+                        color = Color(0xffffe0c5),
+                        style = ElementTheme.typography.fontBodyLgRegular,
+                    )
+                }
+            }
+        }
+        // :tchap: end
+
         val mediaInfo = (state.attachment as? Attachment.Media)?.localMedia?.info
         if (mediaInfo?.isImageAttachment() == true) {
             ImageOptimizationSelector(state.mediaOptimizationSelectorState)

--- a/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
+++ b/features/messages/impl/src/main/kotlin/io/element/android/features/messages/impl/messagecomposer/MessageComposerPresenter.kt
@@ -57,6 +57,7 @@ import io.element.android.libraries.matrix.api.room.JoinedRoom
 import io.element.android.libraries.matrix.api.room.draft.ComposerDraft
 import io.element.android.libraries.matrix.api.room.draft.ComposerDraftType
 import io.element.android.libraries.matrix.api.room.getDirectRoomMember
+import io.element.android.libraries.matrix.api.room.join.JoinRule
 import io.element.android.libraries.matrix.api.room.powerlevels.use
 import io.element.android.libraries.matrix.api.timeline.TimelineException
 import io.element.android.libraries.matrix.api.timeline.item.event.toEventOrTransactionId
@@ -223,9 +224,15 @@ class MessageComposerPresenter(
 
         val textEditorState by rememberUpdatedState(
             if (showTextFormatting) {
-                TextEditorState.Rich(richTextEditorState, roomInfo.isEncrypted == true)
+                // :tchap: Warning on file upload when room is not encrypted
+//                TextEditorState.Rich(richTextEditorState, roomInfo.isEncrypted == true)
+                TextEditorState.Rich(richTextEditorState, roomInfo.isEncrypted == true, roomInfo.joinRule == JoinRule.Public)
+                // :tchap: end
             } else {
-                TextEditorState.Markdown(markdownTextEditorState, roomInfo.isEncrypted == true)
+                // :tchap: Warning on file upload when room is not encrypted
+//                TextEditorState.Markdown(markdownTextEditorState, roomInfo.isEncrypted == true)
+                TextEditorState.Markdown(markdownTextEditorState, roomInfo.isEncrypted == true, roomInfo.joinRule == JoinRule.Public)
+                // :tchap: end
             }
         )
 

--- a/features/messages/impl/src/main/res/values-fr/strings_tchap.xml
+++ b/features/messages/impl/src/main/res/values-fr/strings_tchap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2026. DINUM
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  ~ EXPRESS OR IMPLIED, INCLUDING BUT NOgit T LIMITED TO THE WARRANTIES OF
+  ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  ~ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  ~ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  ~ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+  ~ OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<resources>
+    <string name="tchap_screen_media_upload_unencrypted_public_warning">"Salon non chiffré et joignable par d'autres agents. N'y partagez pas d'informations personnelles."</string>
+    <string name="tchap_screen_media_upload_unencrypted_warning">"Salon non chiffré. N'y partagez pas d'informations personnelles."</string>
+</resources>

--- a/features/messages/impl/src/main/res/values/strings_tchap.xml
+++ b/features/messages/impl/src/main/res/values/strings_tchap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ MIT License
+  ~
+  ~ Copyright (c) 2026. DINUM
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in all
+  ~ copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  ~ EXPRESS OR IMPLIED, INCLUDING BUT NOgit T LIMITED TO THE WARRANTIES OF
+  ~ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+  ~ IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+  ~ DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+  ~ OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+  ~ OR OTHER DEALINGS IN THE SOFTWARE.
+  -->
+
+<resources>
+    <string name="tchap_screen_media_upload_unencrypted_public_warning">"Unencrypted chat room accessible to other agents. Do not share personal information here."</string>
+    <string name="tchap_screen_media_upload_unencrypted_warning">"Unencrypted chat room. Do not share personal information here."</string>
+</resources>

--- a/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
+++ b/features/messages/impl/src/test/kotlin/io/element/android/features/messages/impl/attachments/AttachmentsPreviewPresenterTest.kt
@@ -904,6 +904,9 @@ class AttachmentsPreviewPresenterTest {
         return AttachmentsPreviewPresenter(
             attachment = aMediaAttachment(localMedia, sendAsFile = sendAsFile),
             onDoneListener = onDoneListener,
+            // :tchap: Warning on file upload when room is not encrypted
+            room = room,
+            // :tchap: end
             mediaSenderFactory = MediaSenderFactory { timelineMode ->
                 DefaultMediaSender(
                     preProcessor = mediaPreProcessor,

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/Fixtures.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/Fixtures.kt
@@ -14,6 +14,9 @@ fun aTextEditorStateMarkdown(
     initialText: String? = "",
     initialFocus: Boolean = false,
     isRoomEncrypted: Boolean? = null,
+    // :tchap: Warning on file upload when room is not encrypted
+    isRoomJoinRulePublic: Boolean? = null,
+    // :tchap: end
 ): TextEditorState {
     return TextEditorState.Markdown(
         aMarkdownTextEditorState(
@@ -21,6 +24,9 @@ fun aTextEditorStateMarkdown(
             initialFocus = initialFocus,
         ),
         isRoomEncrypted = isRoomEncrypted,
+        // :tchap: Warning on file upload when room is not encrypted
+        isRoomJoinRulePublic = isRoomJoinRulePublic,
+        // :tchap: end
     )
 }
 
@@ -40,6 +46,9 @@ fun aTextEditorStateRich(
     initialMarkdown: String = initialText,
     initialFocus: Boolean = false,
     isRoomEncrypted: Boolean? = null,
+    // :tchap: Warning on file upload when room is not encrypted
+    isRoomJoinRulePublic: Boolean? = null,
+    // :tchap: end
 ): TextEditorState {
     return TextEditorState.Rich(
         aRichTextEditorState(
@@ -49,6 +58,9 @@ fun aTextEditorStateRich(
             initialFocus = initialFocus,
         ),
         isRoomEncrypted = isRoomEncrypted,
+        // :tchap: Warning on file upload when room is not encrypted
+        isRoomJoinRulePublic = isRoomJoinRulePublic,
+        // :tchap: end
     )
 }
 

--- a/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/TextEditorState.kt
+++ b/libraries/textcomposer/impl/src/main/kotlin/io/element/android/libraries/textcomposer/model/TextEditorState.kt
@@ -16,14 +16,24 @@ import io.element.android.wysiwyg.compose.RichTextEditorState
 sealed interface TextEditorState {
     val isRoomEncrypted: Boolean?
 
+    // :tchap: Warning on file upload when room is not encrypted
+    val isRoomJoinRulePublic: Boolean?
+    // :tchap: end
+
     data class Markdown(
         val state: MarkdownTextEditorState,
         override val isRoomEncrypted: Boolean?,
+        // :tchap: Warning on file upload when room is not encrypted
+        override val isRoomJoinRulePublic: Boolean?,
+        // :tchap: end
     ) : TextEditorState
 
     data class Rich(
         val richTextEditorState: RichTextEditorState,
         override val isRoomEncrypted: Boolean?,
+        // :tchap: Warning on file upload when room is not encrypted
+        override val isRoomJoinRulePublic: Boolean?,
+        // :tchap: end
     ) : TextEditorState
 
     fun messageHtml(): String? = when (this) {

--- a/tests/uitests/src/test/snapshots/images/features.messages.impl.attachments.preview_AttachmentsPreviewView_10_en.png
+++ b/tests/uitests/src/test/snapshots/images/features.messages.impl.attachments.preview_AttachmentsPreviewView_10_en.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9ead4ed568e240193cb266a575bf4624a8f7e9022d511a7b1917b3d1f3ce22c4
+size 418053


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Texte d'alerte lors du partage d'un fichier dans un salon non chiffré
Fix #227 

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
