### PR TITLE
Activation des commandes dans les messages

### DIFF
--- a/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
+++ b/libraries/featureflag/api/src/main/kotlin/io/element/android/libraries/featureflag/api/FeatureFlags.kt
@@ -129,7 +129,10 @@ enum class FeatureFlags(
         key = "feature.slash_command",
         title = "Parse slash commands in the message composer",
         description = "Allow parsing slash commands in the message composer and perform action.",
-        defaultValue = { false },
+        // :tchap: Enable SlashCommand by default
+//        defaultValue = { false },
+        defaultValue = { true },
+        // :tchap: end
         isFinished = false,
     ),
     RoomThreadList(

--- a/libraries/slashcommands/impl/src/main/kotlin/io/element/android/libraries/slashcommands/impl/Command.kt
+++ b/libraries/slashcommands/impl/src/main/kotlin/io/element/android/libraries/slashcommands/impl/Command.kt
@@ -102,6 +102,9 @@ enum class Command(
         command = "/nick",
         parameters = "<display-name>",
         description = R.string.slash_command_description_nick,
+        // :tchap: Not used in Tchap
+        isSupported = false,
+        // :tchap: end
     ),
     CHANGE_DISPLAY_NAME_FOR_ROOM(
         command = "/myroomnick",
@@ -142,11 +145,17 @@ enum class Command(
         command = "/rainbow",
         parameters = "<message>",
         description = R.string.slash_command_description_rainbow,
+        // :tchap: Wrong display on mobile, disable it
+        isSupported = false,
+        // :tchap: end
     ),
     RAINBOW_EMOTE(
         command = "/rainbowme",
         parameters = "<message>",
         description = R.string.slash_command_description_rainbow_emote,
+        // :tchap: Wrong display on mobile, disable it
+        isSupported = false,
+        // :tchap: end
     ),
     DEVTOOLS(
         command = "/devtools",
@@ -157,6 +166,9 @@ enum class Command(
         command = "/spoiler",
         parameters = "<message>",
         description = R.string.slash_command_description_spoiler,
+        // :tchap: Wrong display on mobile, disable it
+        isSupported = false,
+        // :tchap: end
     ),
     SHRUG(
         command = "/shrug",
@@ -172,11 +184,17 @@ enum class Command(
         command = "/plain",
         parameters = "<message>",
         description = R.string.slash_command_description_plain,
+        // :tchap: Not used in Tchap
+        isSupported = false,
+        // :tchap: end
     ),
     WHOIS(
         command = "/whois",
         parameters = "<user-id>",
         description = R.string.slash_command_description_whois,
+        // :tchap: Only for debug on Tchap
+        isDevCommand = true,
+        // :tchap: end
     ),
     DISCARD_SESSION(
         command = "/discardsession",


### PR DESCRIPTION
<!-- 

Please read [CONTRIBUTING.md](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md) before submitting your pull request.

Are you adding a new feature? Keep in mind that it needs to be added to [the iOS client](https://github.com/element-hq/element-x-ios) too, unless it's related to an Android OS only behaviour.

**IMPORTANT:** if you are adding new screens or modifying existing ones, this needs acceptance from the product and design teams before being merged. For this, it's better to start with a [feature request issue](https://github.com/element-hq/element-x-android/issues/new?template=enhancement.yml) describing the change you want to make and the motivation behind it instead of directly creating a pull request. This will allow the product and design teams to give feedback on the change before you start working on it, and avoid you doing work that might end up being rejected.

-->
 
## Content

Activation des commandes dans les messages

## Motivation and context

<!-- Provide link to the corresponding issue if applicable or explain the context -->

## Screenshots / GIFs

<!--
We have screenshot tests in the project, so attaching screenshots to a PR is not mandatory, as far as there
is a Composable Preview covering the changes. In this case, the change will appear in the file diff.
Note that all the UI composables should be covered by a Composable Preview.

Providing a video of the change is still very useful for the reviewer and for the history of the project.

You can use a table like this to show screenshots comparison.
Uncomment this markdown table below and edit the last line `|||`:
|copy screenshot of before here|copy screenshot of after here|

|Before|After|
|-|-|
|||
 -->

## Tests

<!-- Explain how you tested your development -->

- Step 1
- Step 2
- Step ...

## Tested devices

- [ ] Physical
- [x] Emulator
- OS version(s):

## Checklist

<!-- Depending on the Pull Request content, it can be acceptable if some of the following checkboxes stay unchecked. -->

- [x] I am aware of the [etiquette](https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#etiquette).
- This PR was made with the help of AI:
    - [ ] Yes. In this case, please request a review by Copilot.
    - [x] No.
- [x] Changes have been tested on an Android device or Android emulator with API 24
- [x] UI change has been tested on both light and dark themes
- [ ] Accessibility has been taken into account. See https://github.com/element-hq/element-x-android/blob/develop/CONTRIBUTING.md#accessibility
- [x] Pull request is based on the develop branch
- [x] Pull request title will be used in the release note, it clearly defines what will change for the user
- [x] Pull request includes screenshots or videos if containing UI changes
- [x] You've made a self review of your PR
